### PR TITLE
PR: Fix and improve RangeWidget

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -182,10 +182,11 @@ class RangeWidget(QObject):
         """Set the start and end value of the range."""
         old_start = self.start()
         old_end = self.end()
+        step = 0 if self.null_range_ok else 10**-self.decimals
 
         self._block_spinboxes_signals(True)
-        self.spinbox_start.setMaximum(end)
-        self.spinbox_end.setMinimum(start)
+        self.spinbox_start.setMaximum(self.spinbox_end.maximum() - step)
+        self.spinbox_end.setMinimum(self.spinbox_start.minimum() + step)
         self.spinbox_start.setValue(start)
         self.spinbox_end.setValue(end)
         self._block_spinboxes_signals(False)

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -184,6 +184,8 @@ class RangeWidget(QObject):
         old_end = self.end()
 
         self._block_spinboxes_signals(True)
+        self.spinbox_start.setMaximum(end)
+        self.spinbox_end.setMinimum(start)
         self.spinbox_start.setValue(start)
         self.spinbox_end.setValue(end)
         self._block_spinboxes_signals(False)

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -149,6 +149,9 @@ class RangeWidget(QObject):
         self.decimals = decimals
         self.null_range_ok = null_range_ok
 
+        self._start = minimum
+        self._end = maximum
+
         self.spinbox_start = RangeSpinBox(
             minimum=minimum, singlestep=singlestep, decimals=decimals,
             value=minimum)
@@ -232,4 +235,7 @@ class RangeWidget(QObject):
         Handle when the value of the lowcut or highcut spinbox changed.
         """
         self._update_spinbox_range()
-        self.sig_range_changed.emit(self.start(), self.end())
+        if self._start != self.start() or self._end != self.end():
+            self._start = self.start()
+            self._end = self.end()
+            self.sig_range_changed.emit(self.start(), self.end())

--- a/qtapputils/widgets/tests/test_range.py
+++ b/qtapputils/widgets/tests/test_range.py
@@ -140,20 +140,30 @@ def test_range_widget(range_widget, qtbot):
     assert range_widget.spinbox_end.maximum() == 74.00
     assert range_widget.spinbox_end.value() == 62.3
 
+    # Test that setting a range that is mutually exclusive from the
+    # previous range is working as expected. See geo-stack/qtapputils#28.
+    range_widget.set_range(25, 30)
+    assert range_widget.start() == 25
+    assert range_widget.end() == 30
+
+    range_widget.set_range(65, 70)
+    assert range_widget.start() == 65
+    assert range_widget.end() == 70
+
     # Test entering values in spinbox.
     range_widget.spinbox_start.clear()
     qtbot.keyClicks(range_widget.spinbox_start, '43.51')
     qtbot.keyClick(range_widget.spinbox_start, Qt.Key_Enter)
     assert range_widget.start() == 43.51
-    assert range_widget.end() == 62.3
+    assert range_widget.end() == 70.00
 
     assert range_widget.spinbox_start.minimum() == 24
-    assert range_widget.spinbox_start.maximum() == 62.29
+    assert range_widget.spinbox_start.maximum() == 69.99
     assert range_widget.spinbox_start.value() == 43.51
 
     assert range_widget.spinbox_end.minimum() == 43.52
     assert range_widget.spinbox_end.maximum() == 74.00
-    assert range_widget.spinbox_end.value() == 62.3
+    assert range_widget.spinbox_end.value() == 70.00
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Only emit `sig_range_changed` when the value of the spinbox actually changed
- Fix a bug when trying to set a new range with `RangeWidget.set_range`, when the new range was mutually exclusive from the limits of the previous range.