### PR TITLE
PR: Fix range spinbox validate when more decimal than allowed is entered

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -52,7 +52,7 @@ class DoubleSpinBox(QDoubleSpinBox):
         """
         Override qt base method to work around the bug described at
         https://bugreports.qt.io/browse/QTBUG-77939 when a ',' is
-        used as decimal separator.
+        both used as thousands and decimal separator.
         """
         from qtpy.QtCore import QLocale
         LOCALE = QLocale()
@@ -112,10 +112,16 @@ class RangeSpinBox(DoubleSpinBox):
             return super().fixup(value)
 
         num, success = LOCALE.toDouble(value)
+        if not success:
+            return super().fixup(value)
+
+        num = float(num)
         if float(num) > self.maximum():
             return self.textFromValue(self.maximum())
-        else:
+        elif float(num) < self.minimum():
             return self.textFromValue(self.minimum())
+        else:
+            return self.textFromValue(num)
 
     def validate(self, value, pos):
         """Override Qt method."""
@@ -126,10 +132,15 @@ class RangeSpinBox(DoubleSpinBox):
         if success is False:
             return QValidator.Invalid, value, pos
 
-        if float(num) > self.maximum() or float(num) < self.minimum():
+        num = float(num)
+        if num > self.maximum() or num < self.minimum():
             return QValidator.Intermediate, value, pos
-        else:
-            return QValidator.Acceptable, value, pos
+
+        # Check if the number has more decimals than allowed.
+        if value != self.textFromValue(num):
+            return QValidator.Intermediate, value, pos
+
+        return QValidator.Acceptable, value, pos
 
 
 class RangeWidget(QObject):

--- a/qtapputils/widgets/tests/test_range.py
+++ b/qtapputils/widgets/tests/test_range.py
@@ -120,15 +120,15 @@ def test_range_spinbox(range_spinbox, qtbot):
 
     # Test entering a valid value.
     range_spinbox.clear()
-    qtbot.keyClicks(range_spinbox, '45.3')
+    qtbot.keyClicks(range_spinbox, '45.34823')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
-    assert range_spinbox.value() == 45.3
+    assert range_spinbox.value() == 45.35
 
     # Test entering an intermediate value.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '-')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
-    assert range_spinbox.value() == 45.3
+    assert range_spinbox.value() == 45.35
 
     # Test entering invalid values.
     range_spinbox.clear()


### PR DESCRIPTION
The `RangeSpinbox` is not working as expected when entering a number that has more decimals than the `RangeSpinbox.decimals()`

Current behaviour:

![bug_range_spinbox](https://github.com/user-attachments/assets/277bda85-cb19-4e15-a124-037ac70d3d95)


After the fix:
![bug_range_spinbox_fix](https://github.com/user-attachments/assets/65a4dd42-af33-4c71-8891-83a1db700aaf)

