### PR TITLE
PR: Add precise option to PreciseSpinBox and make RangeSpinBox inherit from PreciseSpinBox

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -114,9 +114,10 @@ class PreciseSpinBox(DoubleSpinBox):
         old_value = self.value()
         new_value = max(min(new_value, self.maximum()), self.minimum())
 
+        was_blocked = self.signalsBlocked()
         self.blockSignals(True)
         super().setValue(new_value)
-        self.blockSignals(False)
+        self.blockSignals(was_blocked)
 
         if self._precise:
             self._true_value = float(new_value)

--- a/qtapputils/widgets/tests/test_range.py
+++ b/qtapputils/widgets/tests/test_range.py
@@ -117,35 +117,44 @@ def test_range_spinbox(range_spinbox, qtbot):
     """
     Test that the RangeSpinBox is working as expected.
     """
+    # Connect a flag to check signal emission
+    emitted_values = []
+    range_spinbox.sig_value_changed.connect(lambda v: emitted_values.append(v))
+
     # Test entering a value above the maximum.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '120')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
     assert range_spinbox.value() == 101
+    assert emitted_values == [101]
 
     # Test entering a value below the minimum.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '-12')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
     assert range_spinbox.value() == 3
+    assert emitted_values == [101, 3]
 
     # Test entering a valid value.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '45.3')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
     assert range_spinbox.value() == 45.3
+    assert emitted_values == [101, 3, 45.3]
 
     # Test entering an intermediate value.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '-')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
     assert range_spinbox.value() == 45.3
+    assert emitted_values == [101, 3, 45.3]
 
     # Test entering invalid values.
     range_spinbox.clear()
     qtbot.keyClicks(range_spinbox, '23..a-45')
     qtbot.keyClick(range_spinbox, Qt.Key_Enter)
     assert range_spinbox.value() == 23.45
+    assert emitted_values == [101, 3, 45.3, 23.45]
 
 
 def test_range_widget(range_widget, qtbot):


### PR DESCRIPTION
Simply to add, optionally, the capability of the `PreciseSpinBox` to `RangeSpinBox `