### PR TITLE
PR: Add a 'block_signals' contextmanager to 'qthelpers

### DIFF
--- a/qtapputils/qthelpers.py
+++ b/qtapputils/qthelpers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from qtpy.QtGui import QIcon
+    from qtapputils.widgets.waitingspinner import WaitingSpinner
 
 # ---- Standard imports
 from contextlib import contextmanager
@@ -26,9 +27,6 @@ from qtpy.QtCore import QByteArray, Qt, QSize
 from qtpy.QtWidgets import (
     QWidget, QSizePolicy, QToolButton, QApplication, QStyleFactory, QAction,
     QToolBar)
-
-# --- Local imports
-from qtapputils.widgets.waitingspinner import WaitingSpinner
 
 
 def qbytearray_to_hexstate(qba):
@@ -174,6 +172,8 @@ def create_waitspinner(
     spinner : WaitingSpinner
         The waitspinner created with the specified parameters
     """
+    from qtapputils.widgets.waitingspinner import WaitingSpinner
+
     dot_padding = 1
 
     # To calculate the size of the dots, we need to solve the following

--- a/qtapputils/qthelpers.py
+++ b/qtapputils/qthelpers.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import (
     QToolBar)
 
 # --- Local imports
-from qtapputils.widgets import WaitingSpinner
+from qtapputils.widgets.waitingspinner import WaitingSpinner
 
 
 def qbytearray_to_hexstate(qba):

--- a/qtapputils/qthelpers.py
+++ b/qtapputils/qthelpers.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from qtpy.QtGui import QIcon
 
 # ---- Standard imports
+from contextlib import contextmanager
 import sys
 import platform
 from math import pi
@@ -254,3 +255,14 @@ def get_default_contents_margins() -> list[int, int, int, int]:
         style.pixelMetric(style.PM_LayoutRightMargin),
         style.pixelMetric(style.PM_LayoutBottomMargin),
         ]
+
+
+@contextmanager
+def block_signals(widget):
+    """Temporarily block signals for the given widget."""
+    was_blocked = widget.signalsBlocked()
+    widget.blockSignals(True)
+    try:
+        yield
+    finally:
+        widget.blockSignals(was_blocked)

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -7,10 +7,15 @@
 # Licensed under the terms of the MIT License.
 # -----------------------------------------------------------------------------
 
+
 # ---- Third party imports
 from qtpy.QtCore import Signal, QObject, QLocale, Qt
 from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import QDoubleSpinBox, QWidget
+
+# ---- Local imports
+from qtapputils.qthelpers import block_signals
+
 
 LOCALE = QLocale()
 
@@ -114,10 +119,8 @@ class PreciseSpinBox(DoubleSpinBox):
         old_value = self.value()
         new_value = max(min(new_value, self.maximum()), self.minimum())
 
-        was_blocked = self.signalsBlocked()
-        self.blockSignals(True)
-        super().setValue(new_value)
-        self.blockSignals(was_blocked)
+        with block_signals(self):
+            super().setValue(new_value)
 
         if self._precise:
             self._true_value = float(new_value)

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -117,13 +117,13 @@ class PreciseSpinBox(DoubleSpinBox):
     def setValue(self, new_value: float):
         """Set the value without losing precision due to display rounding."""
         old_value = self.value()
-        new_value = max(min(new_value, self.maximum()), self.minimum())
+        new_value = float(max(min(new_value, self.maximum()), self.minimum()))
 
         with block_signals(self):
             super().setValue(new_value)
 
         if self._precise:
-            self._true_value = float(new_value)
+            self._true_value = new_value
 
         if old_value != self.value():
             self.sig_value_changed.emit(self.value())


### PR DESCRIPTION
Add a new `contextmanager` to make blocking signals of Qt Widgets easier.