### PR TITLE
PR: Add 'is_running' attribute to TaskManagerBase and minor improvements to code

### DIFF
--- a/qtapputils/managers/taskmanagers.py
+++ b/qtapputils/managers/taskmanagers.py
@@ -97,7 +97,9 @@ class TaskManagerBase(QObject):
 
     @property
     def is_running(self):
-        return len(self._running_tasks + self._pending_tasks) != 0
+        return not (len(self._running_tasks) == 0 and
+                    len(self._pending_tasks) == 0 and
+                    not self._thread.isRunning())
 
     def run_tasks(
             self, callback: Callable = None, returned_values: tuple = None):

--- a/qtapputils/managers/taskmanagers.py
+++ b/qtapputils/managers/taskmanagers.py
@@ -78,8 +78,8 @@ class TaskManagerBase(QObject):
 
         self._worker = None
 
-        self._task_callbacks: dict[uuid.UUID, Callable]
-        self._task_data: dict[uuid.UUID, tuple[str, tuple, dict]]
+        self._task_callbacks: dict[uuid.UUID, Callable] = {}
+        self._task_data: dict[uuid.UUID, tuple[str, tuple, dict]] = {}
 
         self._running_tasks = []
         self._queued_tasks = []

--- a/qtapputils/managers/taskmanagers.py
+++ b/qtapputils/managers/taskmanagers.py
@@ -98,6 +98,10 @@ class TaskManagerBase(QObject):
         #
         # Running tasks are tasks that are being executed by the worker.
 
+    @property
+    def is_running(self):
+        return len(self._running_tasks + self._pending_tasks) != 0
+
     def run_tasks(
             self, callback: Callable = None, returned_values: tuple = None):
         """

--- a/qtapputils/managers/tests/test_taskmanagers.py
+++ b/qtapputils/managers/tests/test_taskmanagers.py
@@ -53,7 +53,7 @@ def task_manager(worker, qtbot):
     yield task_manager
 
     # We wait for the manager's thread to fully stop to avoid segfault error.
-    qtbot.waitUntil(lambda: not task_manager._thread.isRunning())
+    qtbot.waitUntil(lambda: not task_manager.is_running)
 
 
 @pytest.fixture
@@ -63,7 +63,7 @@ def lifo_task_manager(worker, qtbot):
     yield task_manager
 
     # We wait for the manager's thread to fully stop to avoid segfault error.
-    qtbot.waitUntil(lambda: not task_manager._thread.isRunning())
+    qtbot.waitUntil(lambda: not task_manager.is_running)
 
 
 # =============================================================================


### PR DESCRIPTION
This pull request adds an `is_running` property to the `TaskManagerBase` class, providing a clear and reliable way to check whether the task manager is currently processing tasks or has an active worker thread. Additionally, several minor code improvements and refactorings are included for better readability and maintainability.

## Changes

- **Add `is_running` attribute:**  
  - Implements a property that returns `True` when tasks are pending, running, or when the worker thread is active.
  - Improves thread state management and makes it easier for client code to monitor task execution status.
- **Minor code refactoring:**  
  - Adds missing initializations for task dictionaries.
  - Cleans up comments and docstrings for clarity.
  - Enhances code style and consistency.
