### PR TITLE
PR: Rework taskmanager thread management

### DIFF
--- a/qtapputils/managers/tests/test_taskmanagers.py
+++ b/qtapputils/managers/tests/test_taskmanagers.py
@@ -52,8 +52,9 @@ def task_manager(worker, qtbot):
     task_manager.set_worker(worker)
     yield task_manager
 
-    # We wait for the manager's thread to fully stop to avoid segfault error.
-    qtbot.waitUntil(lambda: not task_manager.is_running)
+    task_manager.close()
+    assert not task_manager.is_running
+    assert not task_manager._thread.isRunning()
 
 
 @pytest.fixture
@@ -62,8 +63,9 @@ def lifo_task_manager(worker, qtbot):
     task_manager.set_worker(worker)
     yield task_manager
 
-    # We wait for the manager's thread to fully stop to avoid segfault error.
-    qtbot.waitUntil(lambda: not task_manager.is_running)
+    task_manager.close()
+    assert not task_manager.is_running
+    assert not task_manager._thread.isRunning()
 
 
 # =============================================================================


### PR DESCRIPTION
This pull request refactors and improves the thread management logic in the QtAppUtils task manager. The changes focus on making the thread lifecycle more robust and predictable. Specifically:

- The worker thread is now managed so it persists for the entire lifetime of the task manager object, rather than being started and stopped for each batch of tasks.
- The shutdown logic has been improved. The `close()` method now ensures that all running tasks are completed before the worker thread is quit and joined, reducing the risk of premature thread termination or resource leaks.
- Superfluous code related to thread and task state handling has been removed or simplified, resulting in a cleaner and more maintainable implementation.
- These changes make the task manager more efficient and reliable, particularly in scenarios involving multiple batches of tasks or application shutdown.